### PR TITLE
Revert "count and extract line numbers to top-level, for error handling." 

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,18 +1,5 @@
-use logos::{Extras, Logos};
+use logos::Logos;
 use std::ops::Range;
-#[derive(Default)]
-struct LexState {
-    current_line: usize,
-}
-
-impl Extras for LexState {
-    fn on_advance(&mut self) {}
-    fn on_whitespace(&mut self, byte: u8) {
-        if byte as char == '\n' {
-            self.current_line += 1;
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 pub enum Token<'a> {
@@ -36,7 +23,6 @@ pub enum Token<'a> {
 // Notably absent from the above, present in the below are
 // Whitespace, EOF, LexError
 #[derive(Logos, Debug)]
-#[extras = "LexState"]
 enum _Token_ {
     #[end]
     EOF,
@@ -179,7 +165,7 @@ impl std::fmt::Display for LexicalError {
 }
 
 pub struct Tokens<'a>(logos::Lexer<_Token_, &'a str>);
-pub type Spanned<Tok, Loc, Error> = Result<(Loc, (Tok, usize), Loc), Error>;
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
 
 impl<'a> Tokens<'a> {
     pub fn from_string(source: &'a str) -> Tokens<'a> {
@@ -193,8 +179,7 @@ impl<'a> Iterator for Tokens<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let lex = &mut self.0;
         let range = lex.range();
-        let line = lex.extras.current_line;
-        let ok = |tok: Token<'a>| Ok((range.start, (tok, line), range.end));
+        let ok = |tok: Token<'a>| Ok((range.start, tok, range.end));
         let token = loop {
             match &lex.token {
                 _Token_::Whitespace | _Token_::Comment => lex.advance(),

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,7 @@
 use crate::codespan;
 use crate::error::*;
+use crate::lex;
+use crate::parser;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 
@@ -7,7 +9,12 @@ pub fn do_test<'a>(sources: &[&'a str]) -> Result<(), Vec<(&'a str, Error<'a>)>>
     let (_pass, fail): (Vec<_>, Vec<_>) = sources
         .iter()
         .enumerate()
-        .map(|(index, s)| (index, { crate::parse_string(s).0 }))
+        .map(|(index, s)| {
+            (
+                index,
+                parser::propParser::new().parse(lex::Tokens::from_string(s)),
+            )
+        })
         .partition(|(_, r)| r.is_ok());
     if fail.is_empty() {
         Ok(())


### PR DESCRIPTION
Reverts ratmice/prop#7
codespan-reporting has magic for this already.