### PR TITLE
bump to logos version 0.10-rc2 to fix unicode-char-boundary error,

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 [dependencies]
 lalrpop = "0.18"
 lalrpop-util = "0.18"
-logos = "0.9.7"
+logos = "0.10.0-rc2"
 regex = "1"
-logos-derive = "0.9.7"
+logos-derive = "0.10.0-rc2"
 codespan-reporting = "0.9" 
 structopt = "0.3.12"
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -75,6 +75,8 @@ fn bad_unicode() -> Result<(), MainError> {
     let invalid_source = [
         r"ₐₑₒₓₔₕₖₗₘₙₚₛₜ₀₁₂₃₄₅₆₇₈₉ ≔ ⊤", // Subscript cannot be initial character
         r"\α ≔ ⊤", // Unicode cannot start with slash.
+        r"SomeInvalidSyntaxEndingInUnicodeₐ fooₐ ≔ ⊤",
+        r"ℤSomeInvalidSyntaxₐ ℤfooₐ ≔ ⊤"
     ];
 
     Ok(test_util::expect_fail(test_util::do_test(&invalid_source))?)


### PR DESCRIPTION
add some tests for lalrpop which it seems should exercise the same path...