### PR TITLE
Split lex into the plain logos part, and a token wrapper things.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
-use crate::lex;
-pub type Error<'a> = lalrpop_util::ParseError<usize, lex::Token<'a>, lex::LexicalError>;
+use crate::token_wrap::*;
+
+pub type Error<'a> = lalrpop_util::ParseError<usize, Token<'a>, LexicalError>;
 
 #[derive(Debug)]
 pub enum MainError {

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,29 +1,9 @@
 use logos::Logos;
-use std::ops::Range;
-
-#[derive(Debug, Clone)]
-pub enum Token<'a> {
-    Dot,
-    Semi,
-    Colon,
-    LParen,
-    RParen,
-    Bot,
-    Top,
-    Disj,
-    Conj,
-    Abs,
-    Neg,
-    Iff,
-    Arrow,
-    Def,
-    Name(&'a str),
-}
 
 // Notably absent from the above, present in the below are
 // Whitespace, EOF, LexError
 #[derive(Logos, Debug)]
-enum _Token_ {
+pub enum Token {
     #[end]
     EOF,
 
@@ -132,80 +112,3 @@ enum _Token_ {
     LexError,
 }
 
-impl<'a> std::fmt::Display for Token<'a> {
-    #[rustfmt::skip]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Token::Dot => write!(f, "."), 
-            Token::Abs => write!(f, "ⲗ"),
-            Token::Bot => write!(f, "⊥"),
-            Token::Def => write!(f, "≔"),
-            Token::Iff => write!(f, "↔"),
-            Token::Neg => write!(f, "¬"),
-            Token::Top => write!(f, "⊤"),
-            Token::Conj => write!(f, "∧"),
-            Token::Disj => write!(f, "∨"),
-            Token::Semi => write!(f, ";"),
-            Token::Arrow => write!(f, "→"),
-            Token::Colon => write!(f, ":"),
-            Token::LParen => write!(f, "("),
-            Token::RParen => write!(f, ")"),
-            Token::Name(s)      => write!(f, "{}", s),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct LexicalError(pub Range<usize>);
-
-impl std::fmt::Display for LexicalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "lexical error at {:?}", self.0)
-    }
-}
-
-pub struct Tokens<'a>(logos::Lexer<_Token_, &'a str>);
-pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
-
-impl<'a> Tokens<'a> {
-    pub fn from_string(source: &'a str) -> Tokens<'a> {
-        Tokens(_Token_::lexer(source))
-    }
-}
-
-impl<'a> Iterator for Tokens<'a> {
-    type Item = Spanned<Token<'a>, usize, LexicalError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let lex = &mut self.0;
-        let range = lex.range();
-        let ok = |tok: Token<'a>| Ok((range.start, tok, range.end));
-        let token = loop {
-            match &lex.token {
-                _Token_::Whitespace | _Token_::Comment => lex.advance(),
-                _Token_::EOF => return None,
-                _Token_::LexError => break Err(LexicalError(range)),
-                _Token_::Name => break ok(Token::Name(lex.slice())),
-                _Token_::FancyNameAscii => break ok(Token::Name(lex.slice())),
-                _Token_::FancyNameUnicode => break ok(Token::Name(lex.slice())),
-                // And the rest are all unary members
-                _Token_::Dot => break ok(Token::Dot),
-                _Token_::Abs => break ok(Token::Abs),
-                _Token_::Bot => break ok(Token::Bot),
-                _Token_::Top => break ok(Token::Top),
-                _Token_::Neg => break ok(Token::Neg),
-                _Token_::Iff => break ok(Token::Iff),
-                _Token_::Def => break ok(Token::Def),
-                _Token_::Disj => break ok(Token::Disj),
-                _Token_::Conj => break ok(Token::Conj),
-                _Token_::Semi => break ok(Token::Semi),
-                _Token_::Arrow => break ok(Token::Arrow),
-                _Token_::Colon => break ok(Token::Colon),
-                _Token_::LParen => break ok(Token::LParen),
-                _Token_::RParen => break ok(Token::RParen),
-            }
-        };
-        lex.advance();
-        Some(token)
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod ast;
 mod codespan;
 mod error;
 mod lex;
+mod token_wrap;
 
 #[cfg(test)]
 mod test_util;
@@ -11,9 +12,9 @@ mod test;
 use codespan_reporting::term::termcolor::StandardStream;
 use codespan_reporting::term::{self, ColorArg};
 use error::*;
+use token_wrap::*;
 use std::io::Read;
 use structopt::StructOpt;
-
 #[derive(Debug, StructOpt)]
 #[structopt(name = "prop")]
 pub struct Opts {
@@ -58,7 +59,7 @@ fn main() -> Result<(), MainError> {
 
     // Not really how i'd like this to be.
     buf.read_to_string(&mut s)?;
-    let lexer = lex::Tokens::from_string(&s);
+    let lexer = Tokens::from_string(&s);
     let parse_result = parser::propParser::new().parse(lexer);
 
     match parse_result {

--- a/src/prop.lalrpop
+++ b/src/prop.lalrpop
@@ -1,30 +1,29 @@
-// Bah humbug the auto-generated sources have comments above this comment.
-// #![allow(clippy::all)]
-use crate::lex;
+use crate::token_wrap;
 use crate::ast::{Prop, Expr, Binding, Typ};
 use std::rc::Rc;
+use token_wrap::*;
 grammar<'a>;
 
 extern {
   type Location = usize;
-  type Error = lex::LexicalError;
+  type Error = LexicalError;
 
-  enum lex::Token<'a> {
-	"⊥" => lex::Token::Bot,
-	"." => lex::Token::Dot,
-	"≔" => lex::Token::Def,
-	"→" => lex::Token::Arrow,
-	"↔" => lex::Token::Iff,
-	"¬" => lex::Token::Neg,
-	"ⲗ" => lex::Token::Abs,
-	"∧" => lex::Token::Conj,
-	"∨" => lex::Token::Disj,
-	"⊤" => lex::Token::Top,
-	"(" => lex::Token::LParen,
-	")" => lex::Token::RParen,
-	":" => lex::Token::Colon,
-	";" => lex::Token::Semi,
-	name => lex::Token::Name(<&'a str>),
+  enum Token<'a> {
+	"⊥" => Token::Bot,
+	"." => Token::Dot,
+	"≔" => Token::Def,
+	"→" => Token::Arrow,
+	"↔" => Token::Iff,
+	"¬" => Token::Neg,
+	"ⲗ" => Token::Abs,
+	"∧" => Token::Conj,
+	"∨" => Token::Disj,
+	"⊤" => Token::Top,
+	"(" => Token::LParen,
+	")" => Token::RParen,
+	":" => Token::Colon,
+	";" => Token::Semi,
+	name => Token::Name(<&'a str>),
   }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,7 @@
 use crate::error::*;
-use crate::{lex, parser, test_util};
+use crate::{parser, test_util};
+use crate::token_wrap::*;
+
 use unindent::unindent;
 
 #[test]
@@ -104,7 +106,7 @@ fn bad_ascii() -> Result<(), &'static str> {
 
     let mut num_fail = 0;
     for s in invalid_source.iter() {
-        let lexer = lex::Tokens::from_string(&s);
+        let lexer = Tokens::from_string(&s);
         match parser::propParser::new().parse(lexer) {
             Ok(_) => {
                 // bad

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,6 +1,6 @@
 use crate::codespan;
 use crate::error::*;
-use crate::lex;
+use crate::token_wrap::*;
 use crate::parser;
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
@@ -12,7 +12,7 @@ pub fn do_test<'a>(sources: &[&'a str]) -> Result<(), Vec<(&'a str, Error<'a>)>>
         .map(|(index, s)| {
             (
                 index,
-                parser::propParser::new().parse(lex::Tokens::from_string(s)),
+                parser::propParser::new().parse(Tokens::from_string(s)),
             )
         })
         .partition(|(_, r)| r.is_ok());

--- a/src/token_wrap.rs
+++ b/src/token_wrap.rs
@@ -1,0 +1,100 @@
+use crate::lex;
+use std::ops::Range;
+use logos::Logos;
+
+#[derive(Debug, Clone)]
+pub enum Token<'a> {
+    Dot,
+    Semi,
+    Colon,
+    LParen,
+    RParen,
+    Bot,
+    Top,
+    Disj,
+    Conj,
+    Abs,
+    Neg,
+    Iff,
+    Arrow,
+    Def,
+    Name(&'a str),
+}
+
+impl<'a> std::fmt::Display for Token<'a> {
+    #[rustfmt::skip]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Token::Dot => write!(f, "."), 
+            Token::Abs => write!(f, "ⲗ"),
+            Token::Bot => write!(f, "⊥"),
+            Token::Def => write!(f, "≔"),
+            Token::Iff => write!(f, "↔"),
+            Token::Neg => write!(f, "¬"),
+            Token::Top => write!(f, "⊤"),
+            Token::Conj => write!(f, "∧"),
+            Token::Disj => write!(f, "∨"),
+            Token::Semi => write!(f, ";"),
+            Token::Arrow => write!(f, "→"),
+            Token::Colon => write!(f, ":"),
+            Token::LParen => write!(f, "("),
+            Token::RParen => write!(f, ")"),
+            Token::Name(s)      => write!(f, "{}", s),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct LexicalError(pub Range<usize>);
+
+impl std::fmt::Display for LexicalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "lexical error at {:?}", self.0)
+    }
+}
+
+pub struct Tokens<'a>(logos::Lexer<lex::Token, &'a str>);
+pub type Spanned<Tok, Loc, Error> = Result<(Loc, Tok, Loc), Error>;
+
+impl<'a> Tokens<'a> {
+    pub fn from_string(source: &'a str) -> Tokens<'a> {
+        Tokens(lex::Token::lexer(source))
+    }
+}
+
+impl<'a> Iterator for Tokens<'a> {
+    type Item = Spanned<Token<'a>, usize, LexicalError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let lex = &mut self.0;
+        let range = lex.range();
+        let ok = |tok: Token<'a>| Ok((range.start, tok, range.end));
+        let token = loop {
+            match &lex.token {
+                lex::Token::Whitespace | lex::Token::Comment => lex.advance(),
+                lex::Token::EOF => return None,
+                lex::Token::LexError => break Err(LexicalError(range)),
+                lex::Token::Name => break ok(Token::Name(lex.slice())),
+                lex::Token::FancyNameAscii => break ok(Token::Name(lex.slice())),
+                lex::Token::FancyNameUnicode => break ok(Token::Name(lex.slice())),
+                // And the rest are all unary members
+                lex::Token::Dot => break ok(Token::Dot),
+                lex::Token::Abs => break ok(Token::Abs),
+                lex::Token::Bot => break ok(Token::Bot),
+                lex::Token::Top => break ok(Token::Top),
+                lex::Token::Neg => break ok(Token::Neg),
+                lex::Token::Iff => break ok(Token::Iff),
+                lex::Token::Def => break ok(Token::Def),
+                lex::Token::Disj => break ok(Token::Disj),
+                lex::Token::Conj => break ok(Token::Conj),
+                lex::Token::Semi => break ok(Token::Semi),
+                lex::Token::Arrow => break ok(Token::Arrow),
+                lex::Token::Colon => break ok(Token::Colon),
+                lex::Token::LParen => break ok(Token::LParen),
+                lex::Token::RParen => break ok(Token::RParen),
+            }
+        };
+        lex.advance();
+        Some(token)
+    }
+}


### PR DESCRIPTION
This is largely pulled out of the rowan PR as being able to pull in *just* the logos token structure is sometimes convenient.